### PR TITLE
nodejs: Fix npm audit warnings

### DIFF
--- a/webapp/nodejs/package.json
+++ b/webapp/nodejs/package.json
@@ -10,9 +10,9 @@
     "body-parser": "^1.19.0",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
-    "express": "~4.16.1",
+    "express": "~4.18.2",
     "morgan": "~1.9.1",
-    "xmldom": "^0.4.0",
+    "@xmldom/xmldom": "^0.8.0",
     "xpath": "0.0.32"
   },
   "bugs": {

--- a/webapp/nodejs/routes/index.js
+++ b/webapp/nodejs/routes/index.js
@@ -2,7 +2,7 @@ var express = require('express');
 var router = express.Router();
 var http = require('http');
 var https = require('https');
-var Dom = require('xmldom').DOMParser;
+var Dom = require('@xmldom/xmldom').DOMParser;
 var xpath = require('xpath');
 
 


### PR DESCRIPTION
- upgrade xmldom to 0.8.0
- upgrade express to 4.18.x