### PR TITLE
nodejs: Add https support for both nodejs samples

### DIFF
--- a/webapp/nodejs-esm/README.md
+++ b/webapp/nodejs-esm/README.md
@@ -9,7 +9,9 @@ We assume you are familiar with npm and the node.js framework.
 
 1. In order to install dependencies run `npm intall` in the project folder.
 2. In the console run the `npm start` command for starting the server.
-3. Start your browser and make it point to the url `http://<host>:3000`
+3. Start your browser and make it point to the url
+   `http://<host>:3000` or `https://<host>:3000` depending on whether
+   you setup certifcates (see below).
 
    To make it reachable by the Collabora Online server use as `<host>`
    the IP address of the machine where the NodeJS server is
@@ -33,6 +35,30 @@ We assume you are familiar with npm and the node.js framework.
    * `wopi PutFile endpoint`  - the PutFile wopi endpoint has been triggered
    * ` Hello World! Hi!` - the updated file content has been
      successfully received
+
+### Certificates
+
+It is highly recommended to setup TLS certificates for https.
+
+If you don't have a key pair, I recommend using
+[minica](https://github.com/jsha/minica) to generate a self-signed
+one.
+
+**THIS IS ONLY FOR TEST AND DEVELOPMENT. NEVER USE SELF SIGNED
+CERTIFICATE IN A PRODUCTION ENVIRONMENT**
+
+Then set the environment to indicate where to load the certificate from.
+
+- `SSL_KEY_FILE` contains the path to the private key. If you used
+  the `minica` tool mentionned above, it's the path to the
+  `minica-key.pem` file.
+- `SSL_CRT_FILE` contains the path to the public certificate. If you used
+  the `minica` tool mentionned above, it's the path to the
+  `minica.pem` file.
+
+To use self-signed certificate, NodeJS requires to set the environment
+`NODE_TLS_REJECT_UNAUTHORIZED='0'`, otherwise it will throw a
+`'SELF_SIGNED_CERT_IN_CHAIN'` error.
 
 ## Note
 

--- a/webapp/nodejs/README.md
+++ b/webapp/nodejs/README.md
@@ -9,8 +9,10 @@ We assume you are familiar with npm and the node.js framework.
 
 1. In order to install dependencies run `npm intall` in the project folder.
 2. In the console run the `npm start` command for starting the server.
-3. Start your browser and make it point to the url `http://<host>:3000`
-   
+3. Start your browser and make it point to the url
+   `http://<host>:3000` or `https://<host>:3000` depending on whether
+   you setup certifcates (see below).
+
    To make it reachable by the Collabora Online server use as `<host>` the IP address of the machine where the NodeJS 
    server is running. In case the NodeJs server can't be reached you could also need to open the port 3000 on the firewall. 
    
@@ -27,6 +29,31 @@ We assume you are familiar with npm and the node.js framework.
    * `wopi PutFile endpoint`  - the PutFile wopi endpoint has been triggered
    * ` Hello World! Hi!` - the updated file content has been successfully received
     
+
+### Certificates
+
+It is highly recommended to setup TLS certificates for https.
+
+If you don't have a key pair, I recommend using
+[minica](https://github.com/jsha/minica) to generate a self-signed
+one.
+
+**THIS IS ONLY FOR TEST AND DEVELOPMENT. NEVER USE SELF SIGNED
+CERTIFICATE IN A PRODUCTION ENVIRONMENT**
+
+Then set the environment to indicate where to load the certificate from.
+
+- `SSL_KEY_FILE` contains the path to the private key. If you used
+  the `minica` tool mentionned above, it's the path to the
+  `minica-key.pem` file.
+- `SSL_CRT_FILE` contains the path to the public certificate. If you used
+  the `minica` tool mentionned above, it's the path to the
+  `minica.pem` file.
+
+To use self-signed certificate, NodeJS requires to set the environment
+`NODE_TLS_REJECT_UNAUTHORIZED='0'`, otherwise it will throw a
+`'SELF_SIGNED_CERT_IN_CHAIN'` error.
+
 ## Note
 
 By default the [body-parser][] node.js package used as middleware for the `PutFile` endpoint has a limit option which 

--- a/webapp/nodejs/bin/www
+++ b/webapp/nodejs/bin/www
@@ -3,12 +3,30 @@
 var app = require('../app');
 var debug = require('debug')('untitled:server');
 var http = require('http');
+var https = require('https');
+var fs = require('fs');
+var env = require('process').env;
 
 var port = normalizePort(process.env.PORT || '3000');
 app.set('port', port);
 
-var server = http.createServer(app);
+var server;
+var proto;
 
+var hasCerts = env["SSL_KEY_FILE"] && env["SSL_CRT_FILE"];
+if (hasCerts) {
+  var privateKey = fs.readFileSync(env["SSL_KEY_FILE"]);
+  var certificate = fs.readFileSync(env["SSL_CRT_FILE"]);
+
+  server = https.createServer({
+    key: privateKey,
+    cert: certificate
+  }, app);
+  proto = 'https';
+} else {
+  server = http.createServer(app);
+  proto = 'http';
+}
 server.listen(port);
 server.on('error', onError);
 server.on('listening', onListening);
@@ -60,6 +78,6 @@ function onListening() {
   var addr = server.address();
   var bind = typeof addr === 'string'
     ? 'pipe ' + addr
-    : 'port ' + addr.port;
-  debug('Listening on ' + bind);
+    : `${proto}://localhost:${addr.port}/`;
+  console.log(`Listening on ${bind}`);
 }


### PR DESCRIPTION
- launching the demo server will printout the proper URL to use
- https support is automatic if the environment is setup.
    
Issue #14
