### PR TITLE
reactjs: Fix npm audit warnings (and build)

### DIFF
--- a/webapp/reactjs/client/package.json
+++ b/webapp/reactjs/client/package.json
@@ -14,7 +14,7 @@
     "http-proxy-middleware": "^1.0.6",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-scripts": "4.0.3",
+    "react-scripts": "^5.0.1",
     "typescript": "^4.2.3"
   },
   "scripts": {

--- a/webapp/reactjs/package.json
+++ b/webapp/reactjs/package.json
@@ -7,12 +7,12 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
+    "@xmldom/xmldom": "^0.8.0",
     "body-parser": "^1.19.0",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
-    "express": "~4.16.1",
+    "express": "~4.18.1",
     "morgan": "~1.9.1",
-    "xmldom": "^0.5.0",
     "xpath": "0.0.32"
   },
   "bugs": {

--- a/webapp/reactjs/routes/index.js
+++ b/webapp/reactjs/routes/index.js
@@ -2,7 +2,7 @@ var express = require('express');
 var router = express.Router();
 var http = require('http');
 var https = require('https');
-var Dom = require('xmldom').DOMParser;
+var Dom = require('@xmldom/xmldom').DOMParser;
 var xpath = require('xpath');
 
 /* GET home page. */


### PR DESCRIPTION
- upgrade xmldom to 0.8.0
- upgrade express to 4.18.x
- upgrade react-scripts to 5.0.1
